### PR TITLE
商品一覧表示機能5

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@
 
 - belongs_to :user
 - has_one :addresses
-- belong_to :item
+- belongs_to :item

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
   def index
-    @items = Item.all
+    @items = Item.all 
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
   def index
-    @items = Item.all 
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,18 +126,13 @@
     <%= link_to '新規投稿商品', "/items/:id", class: "subtitle" %>
     <ul class='item-lists'>
 
+    <% if @items.present?%>
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-      <li class='list'>
-        <%@items.each do |item|%>
+      <%@items.each do |item|%>
+        <li class='list'>
           <%= link_to "#" do %>
           <div class='item-img-content'>
             <%= image_tag item.image, class: "item-img" %>
-          
-                <%# 商品が売れていればsold outの表示 %>
-                <%# <div class='sold-out'>
-                  <span>Sold Out!!</span>
-                </div> %>
-                <%# //商品が売れていればsold outの表示 %>
 
           </div>
           <div class='item-info'>
@@ -153,11 +148,10 @@
             </div>
           </div>
           <% end %>
-        <%end%>
-      </li>
+        </li>
+      <%end%>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-    <% if @items%> 
+    <% else %>
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
@@ -191,4 +185,10 @@
     <%= image_tag 'camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>
   </a>
 </div>
-<%= render "shared/footer" %>
+<%= render "shared/footer" %> 
+
+<%# 商品が売れていればsold outの表示 %>
+                <%# <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div> %>
+                <%# //商品が売れていればsold outの表示 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -123,38 +123,41 @@
   <%# 商品一覧 %>
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
-    <%= link_to '新規投稿商品', "#", class: "subtitle" %>
+    <%= link_to '新規投稿商品', "/items/:id", class: "subtitle" %>
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
-        <%= link_to "product_list" do %>
-        <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+        <%@items.each do |item|%>
+          <%= link_to "#" do %>
+          <div class='item-img-content'>
+            <%= image_tag item.image, class: "item-img" %>
+          
+                <%# 商品が売れていればsold outの表示 %>
+                <%# <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div> %>
+                <%# //商品が売れていればsold outの表示 %>
 
-          <%# 商品が売れていればsold outの表示 %>
-          <div class='sold-out'>
-            <span>Sold Out!!</span>
           </div>
-          <%# //商品が売れていればsold outの表示 %>
-
-        </div>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            <%= "商品名" %>
-          </h3>
-          <div class='item-price'>
-            <span><%= "販売価格" %>円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
+          <div class='item-info'>
+            <h3 class='item-name'>
+              <%= item.name %>
+            </h3>
+            <div class='item-price'>
+              <span><%= item.price %>円<br>(税込み)</span>
+              <div class='star-btn'>
+                <%= image_tag "star.png", class:"star-icon" %>
+                <span class='star-count'>0</span>
+              </div>
             </div>
           </div>
-        </div>
-        <% end %>
+          <% end %>
+        <%end%>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
+    <% if @items%> 
       <%# 商品がない場合のダミー %>
       <%# 商品がある場合は表示されないようにしましょう %>
       <li class='list'>
@@ -174,10 +177,12 @@
         </div>
         <% end %>
       </li>
+    <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合のダミー %>
     </ul>
   </div>
+
   <%# //商品一覧 %>
 </div>
 <div class='purchase-btn'>


### PR DESCRIPTION
＃what
画像が表示されており、画像がリンク切れなどになっていないこと、出品した商品の一覧表示ができている。かつ「画像/価格/商品名」の3つの情報について表示できていること、ログアウトした状態でも商品一覧ページを見ることができること。の実装をした。
売却済みの商品は、「sold out」の文字が表示されるようになっていることと、出品されていたら表示されない餃子の商品イラストは購入機能が完成してから実装する。

＃why
商品一覧表示機能するため。